### PR TITLE
PHP 8.4: fix usage of deprecated implicitly nullable parameters

### DIFF
--- a/src/Nmap/Service.php
+++ b/src/Nmap/Service.php
@@ -19,7 +19,7 @@ class Service
 
     private ?string $version;
 
-    public function __construct(string $name = null, string $product = null, string $version = null)
+    public function __construct(?string $name = null, ?string $product = null, ?string $version = null)
     {
         $this->name = $name;
         $this->product = $product;


### PR DESCRIPTION
Seems like #8 missed some code places were parameters are declared nullable implicitly.

This is deprecated in PHP 8.4: https://wiki.php.net/rfc/deprecate-implicitly-nullable-types