### PR TITLE
Fix XML parsing when host is down

### DIFF
--- a/src/Nmap/XmlOutputParser.php
+++ b/src/Nmap/XmlOutputParser.php
@@ -172,7 +172,7 @@ class XmlOutputParser
             throw new \InvalidArgumentException("{$this->xmlFile} does not appear to be valid.");
         }
 
-        if ($xml->runstats->hosts->up === '0') {
+        if ((string) $xml->runstats->hosts->attributes()->up === '0') {
             return [];
         }
 

--- a/src/Nmap/XmlOutputParser.php
+++ b/src/Nmap/XmlOutputParser.php
@@ -168,7 +168,15 @@ class XmlOutputParser
     {
         $xml = simplexml_load_file($this->xmlFile);
 
-        if (!$xml instanceof SimpleXMLElement || !isset($xml->host)) {
+        if (!$xml instanceof SimpleXMLElement || !isset($xml->runstats->hosts)) {
+            throw new \InvalidArgumentException("{$this->xmlFile} does not appear to be valid.");
+        }
+
+        if ($xml->runstats->hosts->up === '0') {
+            return [];
+        }
+
+        if (!isset($xml->host)) {
             throw new \InvalidArgumentException("{$this->xmlFile} does not appear to be valid.");
         }
 


### PR DESCRIPTION
When the host is down, the XML is:

```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE nmaprun>
<?xml-stylesheet href="file:///usr/bin/../share/nmap/nmap.xsl" type="text/xsl"?>
<!-- Nmap 7.93 scan initiated Mon Aug 25 18:50:37 2025 as: /usr/bin/nmap &quot;-p 80,443&quot; -oX /tmp/nmap-scan-output.xmloXXXXvo XXXX.com -->
<nmaprun scanner="nmap" args="/usr/bin/nmap &quot;-p 80,443&quot; -oX /tmp/nmap-scan-output.xmloXXXXvo XXXX.com" start="1756140637" startstr="Mon Aug 25 18:50:37 2025" version="7.93" xmloutputversion="1.05">
<scaninfo type="connect" protocol="tcp" numservices="2" services="80,443"/>
<verbose level="0"/>
<debugging level="0"/>
<runstats><finished time="1756140640" timestr="Mon Aug 25 18:50:40 2025" summary="Nmap done at Mon Aug 25 18:50:40 2025; 1 IP address (0 hosts up) scanned in 3.81 seconds" elapsed="3.81" exit="success"/><hosts up="0" down="1" total="1"/>
</runstats>
</nmaprun>
```

In this case, XmlOutputParser incorrectly throws an exception saying that the XML is invalid.

I propose this change to deal with both responding and non-responding hosts.

Feel free to improve it.

Best regards