### PR TITLE
Avoid mixing targets and options

### DIFF
--- a/src/Nmap/Nmap.php
+++ b/src/Nmap/Nmap.php
@@ -109,6 +109,8 @@ class Nmap
         $options[] = '-oX';
         $options[] = $this->outputFile;
 
+        $options[] = '--'; // so targets are not options
+        
         return array_merge([$this->executable], $options, $targets);
     }
 


### PR DESCRIPTION
If a third party provides targets such as -a.test.com or even "test -v" those would be considered as options by nmap:

```
[RuntimeException]                                                                                                      
  Failed to execute "/usr/bin/nmap -p 80,443 -n -Pn -oX /tmp/nmap-scan-output.xmlvjbeejccuof4clTgViG -34.test.com"  
  /usr/bin/nmap: unrecognized option '-34.test.com'                                                                 
  See the output of nmap -h for a summary of options. 
```

We fix this.

