### PR TITLE
Update condition for empty hostnames

### DIFF
--- a/src/Nmap/XmlOutputParser.php
+++ b/src/Nmap/XmlOutputParser.php
@@ -194,7 +194,7 @@ class XmlOutputParser
 
             $hostnameElement = $xmlHost->hostnames?->hostname ?? null;
 
-            if (!$hostnameElement instanceof SimpleXMLElement) {
+            if (!$hostnameElement instanceof SimpleXMLElement && $hostnameElement !== null) {
                 continue; // ? log ? throw?
             }
 


### PR DESCRIPTION
In some cases, we get XML like

```
<hostnames>
</hostnames>
```

Because the check doesn't allow us to proceed further in this case, the file can't be parsed.

As far as I can see, nothing should break, because almost immediately we have isset for hostname

```
isset($xmlHost->hostnames->hostname)
```